### PR TITLE
Add a macro to easily run and serve examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,23 @@ include = ["src/**/*.rs", "README.md", "LICENSE.Apache-2.0", "LICENSE.MIT"]
 
 [features]
 wasm-opt = ["binary-install", "platforms"]
+run-example = ["xtask-wasm-run-example", "console_error_panic_hook", "wasm-bindgen", "env_logger"]
 
 [dependencies]
 binary-install = { version = "0.0.2", optional = true }
+console_error_panic_hook = { version = "0.1.7", optional = true }
+env_logger = { version = "0.9.0", optional = true }
 fs_extra = "1.2.0"
 lazy_static = "1.4.0"
 log = "0.4.14"
 platforms = { version = "2.0.0", optional = true }
+wasm-bindgen = { version = "0.2.78", optional = true }
 wasm-bindgen-cli-support = "0.2.68"
+xtask-wasm-run-example = { path = "./xtask-wasm-run-example", optional = true }
 xtask-watch = { version = "0.1.0", git = "https://github.com/rustminded/xtask-watch" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.112"
 
 [workspace]
+members = ["xtask-wasm-run-example"]

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The available subcommands are:
     * In the file `Cargo.toml`:
         ```toml
         [dev-dependencies]
-        xtask-wasm = { path = "../../..", features = ["run-example"] }
+        xtask-wasm = { version = "*", features = ["run-example"] }
         ```
     * Then to run the dev server with the example:
         ```console

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The available subcommands are:
 
 * Make an example that will run the dev server:
     * In the file `examples/my_example.rs`, create your example:
-        ```rust,no_build
+        ```rust
         use wasm_bindgen::prelude::*;
 
         #[wasm_bindgen]

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ flexible enough to be customized for most use-cases.
 
 You can find further information for each type at their documentation level.
 
+This library also provides a helper to run examples in the `examples/` directory using a
+development server. This is under the feature `run-example`.
+
 # Examples
 
 * A basic implementation could look like this:
@@ -182,11 +185,37 @@ The available subcommands are:
     cargo xtask serve
     ```
 
+* Make an example that will run the dev server:
+    * In the file `examples/my_example.rs`, create your example:
+        ```rust
+        use wasm_bindgen::prelude::*;
+
+        #[wasm_bindgen]
+        extern "C" {
+            #[wasm_bindgen(js_namespace = console)]
+            fn log(message: &str);
+        }
+
+        #[xtask_wasm::run_example]
+        fn run_app() {
+            log("Hello World!");
+        }
+        ```
+    * In the file `Cargo.toml`:
+        ```toml
+        [dev-dependencies]
+        xtask-wasm = { path = "../../..", features = ["run-example"] }
+        ```
+    * Then to run the dev server with the example:
+        ```console
+        cargo run --example my_example.rs
+        ```
+
 Additional flags can be found using `cargo xtask <subcommand> --help`
 
 # Features
 
-* `wasm-opt`: enable the [`WasmOpt`](https://docs.rs/xtask-wasm/latest/xtask_wasm/wasm_opt/struct.WasmOpt.html) struct that helps downloading and using
-    [`wasm-opt`](https://github.com/WebAssembly/binaryen#tools) very easily.
+* `wasm-opt`: enable the [`WasmOpt`](https://docs.rs/xtask-wasm/latest/xtask_wasm/wasm_opt/struct.WasmOpt.html) struct that helps downloading
+    and using [`wasm-opt`](https://github.com/WebAssembly/binaryen#tools) very easily.
 
 <!-- cargo-rdme end -->

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The available subcommands are:
 
 * Make an example that will run the dev server:
     * In the file `examples/my_example.rs`, create your example:
-        ```rust
+        ```rust,no_build
         use wasm_bindgen::prelude::*;
 
         #[wasm_bindgen]

--- a/examples/demo/webapp/Cargo.toml
+++ b/examples/demo/webapp/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 yew = "0.18"
+
+[dev-dependencies]
+xtask-wasm = { path = "../../..", features = ["run-example"] }

--- a/examples/demo/webapp/examples/run_example.rs
+++ b/examples/demo/webapp/examples/run_example.rs
@@ -1,0 +1,12 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(message: &str);
+}
+
+#[xtask_wasm::run_example]
+fn run_app() {
+    log("Hello World!");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,3 +213,14 @@ pub fn default_build_command() -> Command {
     command.args(["build", "--target", "wasm32-unknown-unknown"]);
     command
 }
+
+#[cfg(feature = "run-example")]
+pub use console_error_panic_hook;
+#[cfg(feature = "run-example")]
+pub use env_logger;
+#[cfg(feature = "run-example")]
+pub use log;
+#[cfg(feature = "run-example")]
+pub use wasm_bindgen;
+#[cfg(feature = "run-example")]
+pub use xtask_wasm_run_example::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@
 use std::process::Command;
 
 pub use xtask_watch::{
-    anyhow, cargo_metadata, cargo_metadata::camino, clap, metadata, package, Watch,
+    anyhow, cargo_metadata, cargo_metadata::camino, clap, metadata, package, xtask_command, Watch,
 };
 
 mod dev_server;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,9 @@
 //!
 //! You can find further information for each type at their documentation level.
 //!
+//! This library also provides a helper to run examples in the `examples/` directory using a
+//! development server. This is under the feature `run-example`.
+//!
 //! # Examples
 //!
 //! * A basic implementation could look like this:
@@ -180,12 +183,38 @@
 //!     cargo xtask serve
 //!     ```
 //!
+//! * Make an example that will run the dev server:
+//!     * In the file `examples/my_example.rs`, create your example:
+//!         ```rust,no_run
+//!         use wasm_bindgen::prelude::*;
+//!
+//!         #[wasm_bindgen]
+//!         extern "C" {
+//!             #[wasm_bindgen(js_namespace = console)]
+//!             fn log(message: &str);
+//!         }
+//!
+//!         #[xtask_wasm::run_example]
+//!         fn run_app() {
+//!             log("Hello World!");
+//!         }
+//!         ```
+//!     * In the file `Cargo.toml`:
+//!         ```toml
+//!         [dev-dependencies]
+//!         xtask-wasm = { path = "../../..", features = ["run-example"] }
+//!         ```
+//!     * Then to run the dev server with the example:
+//!         ```console
+//!         cargo run --example my_example.rs
+//!         ```
+//!
 //! Additional flags can be found using `cargo xtask <subcommand> --help`
 //!
 //! # Features
 //!
-//! * `wasm-opt`: enable the [`WasmOpt`](crate::wasm_opt::WasmOpt) struct that helps downloading and using
-//!     [`wasm-opt`](https://github.com/WebAssembly/binaryen#tools) very easily.
+//! * `wasm-opt`: enable the [`WasmOpt`](crate::wasm_opt::WasmOpt) struct that helps downloading
+//!     and using [`wasm-opt`](https://github.com/WebAssembly/binaryen#tools) very easily.
 
 #![deny(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@
 //!
 //! * Make an example that will run the dev server:
 //!     * In the file `examples/my_example.rs`, create your example:
-//!         ```rust,no_run
+//!         ```rust,ignore
 //!         use wasm_bindgen::prelude::*;
 //!
 //!         #[wasm_bindgen]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@
 //!     * In the file `Cargo.toml`:
 //!         ```toml
 //!         [dev-dependencies]
-//!         xtask-wasm = { path = "../../..", features = ["run-example"] }
+//!         xtask-wasm = { version = "*", features = ["run-example"] }
 //!         ```
 //!     * Then to run the dev server with the example:
 //!         ```console

--- a/xtask-wasm-run-example/Cargo.toml
+++ b/xtask-wasm-run-example/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "xtask-wasm-run-example"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.36"
+quote = "1.0.15"
+syn = { version = "1.0.86", features = ["full"] }

--- a/xtask-wasm-run-example/src/lib.rs
+++ b/xtask-wasm-run-example/src/lib.rs
@@ -88,8 +88,8 @@ impl RunExample {
                     .init();
 
                 let cli: Cli = clap::Parser::parse();
-                let mut dist_command = std::process::Command::new("cargo");
-                dist_command.args(["run", "--example", module_path!(), "--", "dist"]);
+                let mut dist_command = std::process::Command::new(std::env::args().next().unwrap());
+                dist_command.arg("dist");
 
                 match cli.command {
                     Some(Command::Dist(mut dist)) => {

--- a/xtask-wasm-run-example/src/lib.rs
+++ b/xtask-wasm-run-example/src/lib.rs
@@ -1,0 +1,116 @@
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+use syn::{parse, parse_macro_input};
+
+#[proc_macro_attribute]
+pub fn run_example(
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let item = parse_macro_input!(item as syn::ItemFn);
+    let attr = parse_macro_input!(attr with RunExample::parse);
+
+    attr.generate(item)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}
+
+struct RunExample {
+    index: Option<syn::Expr>,
+}
+
+impl RunExample {
+    fn parse(input: parse::ParseStream) -> parse::Result<Self> {
+        let mut index = None;
+
+        while !input.is_empty() {
+            let ident: syn::Ident = input.parse()?;
+            let _eq_token: syn::Token![=] = input.parse()?;
+            let expr: syn::Expr = input.parse()?;
+
+            match ident.to_string().as_str() {
+                "index" => index = Some(expr),
+                _ => return Err(parse::Error::new(ident.span(), "unrecognized argument")),
+            }
+
+            let _comma_token: syn::Token![,] = match input.parse() {
+                Ok(x) => x,
+                Err(_) if input.is_empty() => break,
+                Err(err) => return Err(err),
+            };
+        }
+
+        Ok(RunExample { index })
+    }
+
+    fn generate(self, item: syn::ItemFn) -> syn::Result<proc_macro2::TokenStream> {
+        let fn_block = item.block;
+        let index = if let Some(expr) = self.index {
+            let span = expr.span();
+            quote_spanned! {span=> #expr }
+        } else {
+            quote! { r#"<!DOCTYPE html><html><head><meta charset="utf-8"/><script type="module">import init from "/app.js";init(new URL('app.wasm', import.meta.url));</script></head><body></body></html>"# }
+        };
+
+        Ok(quote! {
+            pub mod xtask_wasm_run_example {
+                use super::*;
+                use xtask_wasm::wasm_bindgen;
+
+                #[xtask_wasm::wasm_bindgen::prelude::wasm_bindgen(start)]
+                pub fn run_app() -> Result<(), xtask_wasm::wasm_bindgen::JsValue> {
+                    xtask_wasm::console_error_panic_hook::set_once();
+
+                    #fn_block
+
+                    Ok(())
+                }
+            }
+
+            fn main() -> xtask_wasm::anyhow::Result<()> {
+                use xtask_wasm::{env_logger, log, clap};
+
+                #[derive(clap::Parser)]
+                struct Cli {
+                    #[clap(subcommand)]
+                    command: Option<Command>,
+                }
+
+                #[derive(clap::Parser)]
+                enum Command {
+                    Dist(xtask_wasm::Dist),
+                    Start(xtask_wasm::DevServer),
+                }
+
+                env_logger::builder()
+                    .filter(Some(module_path!()), log::LevelFilter::Info)
+                    .filter(Some("xtask"), log::LevelFilter::Info)
+                    .init();
+
+                let cli: Cli = clap::Parser::parse();
+                let mut dist_command = std::process::Command::new("cargo");
+                dist_command.args(["run", "--example", module_path!(), "--", "dist"]);
+
+                match cli.command {
+                    Some(Command::Dist(mut dist)) => {
+                        let xtask_wasm::DistResult { dist_dir, .. } = dist
+                            .example(module_path!())
+                            .app_name("app")
+                            .run(env!("CARGO_PKG_NAME"))?;
+                        std::fs::write(dist_dir.join("index.html"), #index)?;
+                        Ok(())
+                    }
+                    Some(Command::Start(dev_server)) => {
+                        let served_path = xtask_wasm::default_dist_dir(false);
+                        dev_server.command(dist_command).start(served_path)
+                    }
+                    None => {
+                        let dev_server: xtask_wasm::DevServer = clap::Parser::parse();
+                        let served_path = xtask_wasm::default_dist_dir(false);
+                        dev_server.command(dist_command).start(served_path)
+                    }
+                }
+            }
+        })
+    }
+}

--- a/xtask-wasm-run-example/src/lib.rs
+++ b/xtask-wasm-run-example/src/lib.rs
@@ -88,7 +88,7 @@ impl RunExample {
                     .init();
 
                 let cli: Cli = clap::Parser::parse();
-                let mut dist_command = std::process::Command::new(std::env::args().next().unwrap());
+                let mut dist_command = xtask_wasm::xtask_command();
                 dist_command.arg("dist");
 
                 match cli.command {


### PR DESCRIPTION
This is answering to:
> cargo run --example n (for wasm) would be awesome too, it's what I miss most.

Source: https://twitter.com/Nazariglez/status/1333850252978376704?s=20&t=x-Iefuv4atmpQrWAISnJ0Q