### PR TITLE
Fix build failures when using run-example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,9 @@ xtask-watch = { version = "0.1.1" }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.112"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [workspace]
 members = ["xtask-wasm-run-example"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,20 @@ wasm-opt = ["binary-install", "platforms"]
 run-example = ["xtask-wasm-run-example", "console_error_panic_hook", "wasm-bindgen", "env_logger"]
 
 [dependencies]
-binary-install = { version = "0.0.2", optional = true }
+xtask-wasm-run-example = { version = "0.1.0", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = { version = "0.1.7", optional = true }
+wasm-bindgen = { version = "0.2.78", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+binary-install = { version = "0.0.2", optional = true }
 env_logger = { version = "0.9.0", optional = true }
 fs_extra = "1.2.0"
 lazy_static = "1.4.0"
 log = "0.4.14"
 platforms = { version = "2.0.0", optional = true }
-wasm-bindgen = { version = "0.2.78", optional = true }
 wasm-bindgen-cli-support = "0.2.68"
-xtask-wasm-run-example = { version = "0.1.0", optional = true }
 xtask-watch = { version = "0.1.1" }
 
 [target.'cfg(unix)'.dependencies]

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 default-members = ["webapp"]
 members = ["webapp", "xtask"]
+
+[patch.crates-io]
+xtask-wasm-run-example = { path = "../../xtask-wasm-run-example" }

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,0 +1,39 @@
+#![allow(unused_macros)]
+
+macro_rules! cfg_wasm32 {
+    ($($item:item)*) => {
+        $(
+            #[cfg(target_arch = "wasm32")]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_not_wasm32 {
+    ($($item:item)*) => {
+        $(
+            #[cfg(not(target_arch = "wasm32"))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_run_example {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "run-example")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "run-example")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_wasm_opt {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "wasm-opt")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "wasm-opt")))]
+            $item
+        )*
+    }
+}

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -166,68 +166,68 @@ impl Dist {
             .unwrap_or_else(|| default_dist_dir(self.release).as_std_path().to_path_buf());
 
         log::trace!("Initializing dist process");
-        let mut build_process = self.build_command;
+        let mut build_command = self.build_command;
 
         if self.run_in_workspace {
-            build_process.current_dir(&metadata.workspace_root);
+            build_command.current_dir(&metadata.workspace_root);
         }
 
         if self.quiet {
-            build_process.arg("--quiet");
+            build_command.arg("--quiet");
         }
 
         if let Some(number) = self.jobs {
-            build_process.args(["--jobs", &number]);
+            build_command.args(["--jobs", &number]);
         }
 
         if let Some(profile) = self.profile {
-            build_process.args(["--profile", &profile]);
+            build_command.args(["--profile", &profile]);
         }
 
         if self.release {
-            build_process.arg("--release");
+            build_command.arg("--release");
         }
 
         for feature in &self.features {
-            build_process.args(["--features", feature]);
+            build_command.args(["--features", feature]);
         }
 
         if self.all_features {
-            build_process.arg("--all-features");
+            build_command.arg("--all-features");
         }
 
         if self.no_default_features {
-            build_process.arg("--no-default-features");
+            build_command.arg("--no-default-features");
         }
 
         if self.verbose {
-            build_process.arg("--verbose");
+            build_command.arg("--verbose");
         }
 
         if let Some(color) = self.color {
-            build_process.args(["--color", &color]);
+            build_command.args(["--color", &color]);
         }
 
         if self.frozen {
-            build_process.arg("--frozen");
+            build_command.arg("--frozen");
         }
 
         if self.locked {
-            build_process.arg("--locked");
+            build_command.arg("--locked");
         }
 
         if self.offline {
-            build_process.arg("--offline");
+            build_command.arg("--offline");
         }
 
         if self.ignore_rust_version {
-            build_process.arg("--ignore-rust-version");
+            build_command.arg("--ignore-rust-version");
         }
 
-        build_process.args(["--package", package_name]);
+        build_command.args(["--package", package_name]);
 
         if let Some(example) = &self.example {
-            build_process.args(["--example", example]);
+            build_command.args(["--example", example]);
         }
 
         let build_dir = metadata
@@ -252,7 +252,7 @@ impl Dist {
 
         log::trace!("Spawning build process");
         ensure!(
-            build_process
+            build_command
                 .status()
                 .context("could not start cargo")?
                 .success(),

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -237,11 +237,11 @@ impl Dist {
         let input_path = if let Some(example) = &self.example {
             build_dir
                 .join("examples")
-                .join(&example.replace("-", "_"))
+                .join(&example.replace('-', "_"))
                 .with_extension("wasm")
         } else {
             build_dir
-                .join(&package_name.replace("-", "_"))
+                .join(&package_name.replace('-', "_"))
                 .with_extension("wasm")
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! This crate aims to provide an easy and customizable way to help you build
 //! Wasm projects by extending them with custom subcommands, based on the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,6 @@ cfg_not_wasm32! {
     cfg_run_example! {
         pub use env_logger;
         pub use log;
-        pub use xtask_wasm_run_example::*;
     }
 
     cfg_wasm_opt! {
@@ -246,6 +245,9 @@ cfg_wasm32! {
     cfg_run_example! {
         pub use console_error_panic_hook;
         pub use wasm_bindgen;
-        pub use xtask_wasm_run_example::*;
     }
+}
+
+cfg_run_example! {
+    pub use xtask_wasm_run_example::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,40 +204,48 @@
 //! * `run-example`: a helper to run examples from `examples/` directory using a development
 //!     server.
 
-use std::process::Command;
+#[macro_use]
+mod cfg;
 
-pub use xtask_watch::{
-    anyhow, cargo_metadata, cargo_metadata::camino, clap, metadata, package, xtask_command, Watch,
-};
+cfg_not_wasm32! {
+    use std::process::Command;
 
-mod dev_server;
-mod dist;
+    pub use xtask_watch::{
+        anyhow, cargo_metadata, cargo_metadata::camino, clap, metadata, package, xtask_command,
+        Watch,
+    };
 
-#[cfg(feature = "wasm-opt")]
-mod wasm_opt;
+    mod dev_server;
+    mod dist;
 
-pub use dev_server::*;
-pub use dist::*;
+    pub use dev_server::*;
+    pub use dist::*;
 
-#[cfg(feature = "run-example")]
-pub use console_error_panic_hook;
-#[cfg(feature = "run-example")]
-pub use env_logger;
-#[cfg(feature = "run-example")]
-pub use log;
-#[cfg(feature = "run-example")]
-pub use wasm_bindgen;
-#[cfg(feature = "run-example")]
-pub use xtask_wasm_run_example::*;
+    cfg_run_example! {
+        pub use env_logger;
+        pub use log;
+        pub use xtask_wasm_run_example::*;
+    }
 
-#[cfg(feature = "wasm-opt")]
-pub use wasm_opt::*;
+    cfg_wasm_opt! {
+        mod wasm_opt;
+        pub use wasm_opt::*;
+    }
 
-/// Get the default command for the build in the dist process.
-///
-/// This is `cargo build --target wasm32-unknown-unknown`.
-pub fn default_build_command() -> Command {
-    let mut command = Command::new("cargo");
-    command.args(["build", "--target", "wasm32-unknown-unknown"]);
-    command
+    /// Get the default command for the build in the dist process.
+    ///
+    /// This is `cargo build --target wasm32-unknown-unknown`.
+    pub fn default_build_command() -> Command {
+        let mut command = Command::new("cargo");
+        command.args(["build", "--target", "wasm32-unknown-unknown"]);
+        command
+    }
+}
+
+cfg_wasm32! {
+    cfg_run_example! {
+        pub use console_error_panic_hook;
+        pub use wasm_bindgen;
+        pub use xtask_wasm_run_example::*;
+    }
 }

--- a/xtask-wasm-run-example/src/lib.rs
+++ b/xtask-wasm-run-example/src/lib.rs
@@ -87,6 +87,7 @@ impl RunExample {
         };
 
         Ok(quote! {
+            #[cfg(target_arch = "wasm32")]
             pub mod xtask_wasm_run_example {
                 use super::*;
                 use xtask_wasm::wasm_bindgen;
@@ -101,6 +102,7 @@ impl RunExample {
                 }
             }
 
+            #[cfg(not(target_arch = "wasm32"))]
             fn main() -> xtask_wasm::anyhow::Result<()> {
                 use xtask_wasm::{env_logger, log, clap};
 
@@ -145,6 +147,9 @@ impl RunExample {
                     }
                 }
             }
+
+            #[cfg(target_arch = "wasm32")]
+            fn main() {}
         })
     }
 }


### PR DESCRIPTION
This PR definitely looks weird :disappointed: 

The idea is to reduce the dependencies when compiling xtask-wasm. This is necessary because when using the feature `run-example`, xtask-wasm is built for x86 **and** for wasm32. xtask-wasm is not really intended to be built for wasm32 but there is no way for the user to avoid this.

Until now we had no issue but it became a problem when using xtask-wasm's `run-example` on example crates in the yew repository. This is because the lock file is using tempfile 3.2 instead of 3.3 like we have here. In [3.3](https://crates.io/crates/tempfile/3.3.0/dependencies) tempfile is using fastrand which can be compiled to wasm32 but in [3.2](https://crates.io/crates/tempfile/3.2.0/dependencies) it is using rand which cannot be compiled to wasm32.

So to solve the issue there are 2 solutions:
 - update tempfile to 3.3 on the yew repository: it's easy but others will have this issue on their own projects
 - reduce the dependencies when compiling xtask-wasm depending on the target so tempfile is not pulled when compiling to wasm32

In the end this looks much better because dependencies that make no sense to be compiled in wasm32 are not compiled in wasm32 and the other way around is true too: wasm-bindgen and console_error_panic_hook are used only when compiling xtask-wasm on wasm32 and should not be pulled when compiling for x86.