### PR TITLE
Add a `new` method to `Dist` and `DevServer`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ walkdir = { version = "2.3.2", optional = true }
 # NOTE: we don't depend on this crate but we need to activate this feature otherwise it's super slow
 walrus = { version = "0.19.0", features = ["parallel"] }
 wasm-bindgen-cli-support = "0.2.68"
-xtask-watch = { version = "0.1.1" }
+xtask-watch = { version = "0.1.2" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.112"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ walkdir = { version = "2.3.2", optional = true }
 # NOTE: we don't depend on this crate but we need to activate this feature otherwise it's super slow
 walrus = { version = "0.19.0", features = ["parallel"] }
 wasm-bindgen-cli-support = "0.2.68"
-xtask-watch = { version = "0.1.2" }
+xtask-watch = { version = "0.1.3" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.112"

--- a/src/dev_server.rs
+++ b/src/dev_server.rs
@@ -185,9 +185,7 @@ impl Default for DevServer {
     }
 }
 
-/// Bind the dev server on the given IP address and port and serve files from the `served_path`
-/// directory. You can also set a path to redirects if the URL can't be found.
-pub fn serve(
+fn serve(
     ip: IpAddr,
     port: u16,
     served_path: impl AsRef<Path>,

--- a/src/dev_server.rs
+++ b/src/dev_server.rs
@@ -86,10 +86,11 @@ pub struct DevServer {
 }
 
 impl DevServer {
-    pub fn new() -> DevServer {
+    /// Create a new dev-server.
+    pub fn new(ip: IpAddr, port: u16) -> DevServer {
         DevServer {
-            ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            port: 8000,
+            ip,
+            port,
             watch: Default::default(),
             command: None,
             not_found_path: None,
@@ -174,11 +175,20 @@ impl DevServer {
 
 impl Default for DevServer {
     fn default() -> DevServer {
-        DevServer::new()
+        DevServer {
+            ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            port: 8000,
+            watch: Default::default(),
+            command: None,
+            not_found_path: None,
+        }
     }
 }
 
 /// Use the dev-server without watcher and command.
+///
+/// Note that the `served_path` needs to be a directory that contains the distributed package
+/// compatible with Wasm (See [`crate::Dist`]).
 pub fn serve(
     ip: IpAddr,
     port: u16,

--- a/src/dev_server.rs
+++ b/src/dev_server.rs
@@ -86,15 +86,12 @@ pub struct DevServer {
 }
 
 impl DevServer {
-    /// Create a new dev-server.
-    pub fn new(ip: IpAddr, port: u16) -> DevServer {
-        DevServer {
-            ip,
-            port,
-            watch: Default::default(),
-            command: None,
-            not_found_path: None,
-        }
+    /// Set the dev-server binding address.
+    pub fn address(mut self, ip: IpAddr, port: u16) -> Self {
+        self.ip = ip;
+        self.port = port;
+
+        self
     }
 
     /// Set the command that is executed when a change is detected.

--- a/src/dev_server.rs
+++ b/src/dev_server.rs
@@ -6,7 +6,7 @@ use crate::{
 use std::{
     ffi, fs,
     io::{prelude::*, BufReader},
-    net::{IpAddr, SocketAddr, TcpListener, TcpStream},
+    net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream},
     path::{Path, PathBuf},
     process,
 };
@@ -86,6 +86,16 @@ pub struct DevServer {
 }
 
 impl DevServer {
+    pub fn new() -> DevServer {
+        DevServer {
+            ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            port: 8000,
+            watch: Default::default(),
+            command: None,
+            not_found_path: None,
+        }
+    }
+
     /// Set the command that is executed when a change is detected.
     pub fn command(mut self, command: process::Command) -> Self {
         self.command = Some(command);
@@ -159,6 +169,12 @@ impl DevServer {
             self.command = Some(crate::xtask_command());
         }
         self.command.as_mut().unwrap()
+    }
+}
+
+impl Default for DevServer {
+    fn default() -> DevServer {
+        DevServer::new()
     }
 }
 

--- a/src/dev_server.rs
+++ b/src/dev_server.rs
@@ -185,10 +185,8 @@ impl Default for DevServer {
     }
 }
 
-/// Use the dev-server without watcher and command.
-///
-/// Note that the `served_path` needs to be a directory that contains the distributed package
-/// compatible with Wasm (See [`crate::Dist`]).
+/// Bind the dev server on the given IP address and port and serve files from the `served_path`
+/// directory. You can also set a path to redirects if the URL can't be found.
 pub fn serve(
     ip: IpAddr,
     port: u16,

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -116,6 +116,7 @@ pub struct Dist {
 }
 
 impl Dist {
+    /// Create a new helper for the distributed package.
     pub fn new() -> Dist {
         Dist {
             quiet: Default::default(),

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -48,7 +48,7 @@ use wasm_bindgen_cli_support::Bindgen;
 #[clap(
     about = "Generate the distributed package.",
     long_about = "Generate the distributed package.\n\
-        It will build and package the project for WASM.",
+        It will build and package the project for WASM."
 )]
 pub struct Dist {
     /// No output printed to stdout.
@@ -339,18 +339,19 @@ impl Dist {
 fn sass(
     static_dir: &std::path::Path,
     dist_dir: &std::path::Path,
-    options: &sass_rs::Options
+    options: &sass_rs::Options,
 ) -> Result<()> {
     fn is_sass(path: &std::path::Path) -> bool {
         matches!(
-            path.extension().and_then(|x| x.to_str().map(|x| x.to_lowercase())).as_deref(),
+            path.extension()
+                .and_then(|x| x.to_str().map(|x| x.to_lowercase()))
+                .as_deref(),
             Some("sass") | Some("scss")
         )
     }
 
     fn should_ignore(path: &std::path::Path) -> bool {
-        path
-            .file_name()
+        path.file_name()
             .expect("WalkDir does not yield paths ending with `..`  or `.`")
             .to_str()
             .map(|x| x.starts_with("_"))
@@ -360,24 +361,27 @@ fn sass(
     log::trace!("Generating dist artifacts");
     let walker = walkdir::WalkDir::new(&static_dir);
     for entry in walker {
-        let entry = entry.with_context(|| format!("cannot walk into directory `{}`", &static_dir.display()))?;
+        let entry = entry
+            .with_context(|| format!("cannot walk into directory `{}`", &static_dir.display()))?;
         let source = entry.path();
         let dest = dist_dir.join(source.strip_prefix(&static_dir).unwrap());
         let _ = fs::create_dir_all(dest.parent().unwrap());
 
         if !source.is_file() {
-            continue
+            continue;
         } else if is_sass(source) {
             if !should_ignore(source) {
-                let dest = dest
-                    .with_extension("css");
+                let dest = dest.with_extension("css");
 
                 let css = sass_rs::compile_file(source, options.clone())
                     .expect("could not convert SASS/ file");
-                fs::write(&dest, css).with_context(|| format!("could not write CSS to file `{}`", dest.display()))?;
+                fs::write(&dest, css)
+                    .with_context(|| format!("could not write CSS to file `{}`", dest.display()))?;
             }
         } else {
-            fs::copy(source, &dest).with_context(|| format!("cannot move `{}` to `{}`", source.display(), dest.display()))?;
+            fs::copy(source, &dest).with_context(|| {
+                format!("cannot move `{}` to `{}`", source.display(), dest.display())
+            })?;
         }
     }
 

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -117,7 +117,7 @@ pub struct Dist {
 
 impl Dist {
     /// Create a new helper for the distributed package.
-    pub fn new() -> Dist {
+    pub fn new(dist_dir_path: Option<PathBuf>, static_dir_path: Option<PathBuf>) -> Dist {
         Dist {
             quiet: Default::default(),
             jobs: Default::default(),
@@ -134,8 +134,8 @@ impl Dist {
             ignore_rust_version: Default::default(),
             example: Default::default(),
             build_command: default_build_command(),
-            dist_dir_path: Default::default(),
-            static_dir_path: Default::default(),
+            dist_dir_path,
+            static_dir_path,
             app_name: Default::default(),
             run_in_workspace: Default::default(),
             #[cfg(feature = "sass")]
@@ -364,7 +364,7 @@ impl Dist {
 
 impl Default for Dist {
     fn default() -> Dist {
-        Dist::new()
+        Dist::new(Default::default(), Default::default())
     }
 }
 

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -116,6 +116,32 @@ pub struct Dist {
 }
 
 impl Dist {
+    pub fn new() -> Dist {
+        Dist {
+            quiet: Default::default(),
+            jobs: Default::default(),
+            profile: Default::default(),
+            release: Default::default(),
+            features: Default::default(),
+            all_features: Default::default(),
+            no_default_features: Default::default(),
+            verbose: Default::default(),
+            color: Default::default(),
+            frozen: Default::default(),
+            locked: Default::default(),
+            offline: Default::default(),
+            ignore_rust_version: Default::default(),
+            example: Default::default(),
+            build_command: default_build_command(),
+            dist_dir_path: Default::default(),
+            static_dir_path: Default::default(),
+            app_name: Default::default(),
+            run_in_workspace: Default::default(),
+            #[cfg(feature = "sass")]
+            sass_options: Default::default(),
+        }
+    }
+
     /// Set the command used by the build process.
     ///
     /// The default command is the result of the [`default_build_command`].
@@ -335,6 +361,12 @@ impl Dist {
     }
 }
 
+impl Default for Dist {
+    fn default() -> Dist {
+        Dist::new()
+    }
+}
+
 #[cfg(feature = "sass")]
 fn sass(
     static_dir: &std::path::Path,
@@ -389,6 +421,7 @@ fn sass(
 }
 
 /// Provides paths of the generated dist artifacts.
+#[derive(Debug, Default)]
 pub struct DistResult {
     /// Directory containing the generated artifacts.
     pub dist_dir: PathBuf,

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -387,7 +387,7 @@ fn sass(
         path.file_name()
             .expect("WalkDir does not yield paths ending with `..`  or `.`")
             .to_str()
-            .map(|x| x.starts_with("_"))
+            .map(|x| x.starts_with('_'))
             .unwrap_or(false)
     }
 

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -44,7 +44,7 @@ use wasm_bindgen_cli_support::Bindgen;
 /// generate JS bindings and output two files: `project.js` and `project.wasm`
 /// into the dist directory.
 #[non_exhaustive]
-#[derive(Debug, Default, clap::Parser)]
+#[derive(Debug, clap::Parser)]
 #[clap(
     about = "Generate the distributed package.",
     long_about = "Generate the distributed package.\n\
@@ -116,11 +116,6 @@ pub struct Dist {
 }
 
 impl Dist {
-    /// Create a new helper for the distributed package.
-    pub fn new() -> Dist {
-        Dist::default()
-    }
-
     /// Set the command used by the build process.
     ///
     /// The default command is the result of the [`default_build_command`].
@@ -340,6 +335,34 @@ impl Dist {
     }
 }
 
+impl Default for Dist {
+    fn default() -> Dist {
+        Dist {
+            quiet: Default::default(),
+            jobs: Default::default(),
+            profile: Default::default(),
+            release: Default::default(),
+            features: Default::default(),
+            all_features: Default::default(),
+            no_default_features: Default::default(),
+            verbose: Default::default(),
+            color: Default::default(),
+            frozen: Default::default(),
+            locked: Default::default(),
+            offline: Default::default(),
+            ignore_rust_version: Default::default(),
+            example: Default::default(),
+            build_command: default_build_command(),
+            dist_dir_path: Default::default(),
+            static_dir_path: Default::default(),
+            app_name: Default::default(),
+            run_in_workspace: Default::default(),
+            #[cfg(feature = "sass")]
+            sass_options: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "sass")]
 fn sass(
     static_dir: &std::path::Path,
@@ -394,7 +417,7 @@ fn sass(
 }
 
 /// Provides paths of the generated dist artifacts.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct DistResult {
     /// Directory containing the generated artifacts.
     pub dist_dir: PathBuf,

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -44,7 +44,7 @@ use wasm_bindgen_cli_support::Bindgen;
 /// generate JS bindings and output two files: `project.js` and `project.wasm`
 /// into the dist directory.
 #[non_exhaustive]
-#[derive(Debug, clap::Parser)]
+#[derive(Debug, Default, clap::Parser)]
 #[clap(
     about = "Generate the distributed package.",
     long_about = "Generate the distributed package.\n\
@@ -117,30 +117,8 @@ pub struct Dist {
 
 impl Dist {
     /// Create a new helper for the distributed package.
-    pub fn new(dist_dir_path: Option<PathBuf>, static_dir_path: Option<PathBuf>) -> Dist {
-        Dist {
-            quiet: Default::default(),
-            jobs: Default::default(),
-            profile: Default::default(),
-            release: Default::default(),
-            features: Default::default(),
-            all_features: Default::default(),
-            no_default_features: Default::default(),
-            verbose: Default::default(),
-            color: Default::default(),
-            frozen: Default::default(),
-            locked: Default::default(),
-            offline: Default::default(),
-            ignore_rust_version: Default::default(),
-            example: Default::default(),
-            build_command: default_build_command(),
-            dist_dir_path,
-            static_dir_path,
-            app_name: Default::default(),
-            run_in_workspace: Default::default(),
-            #[cfg(feature = "sass")]
-            sass_options: Default::default(),
-        }
+    pub fn new() -> Dist {
+        Dist::default()
     }
 
     /// Set the command used by the build process.
@@ -359,12 +337,6 @@ impl Dist {
             js: wasm_js_path,
             wasm: wasm_bin_path,
         })
-    }
-}
-
-impl Default for Dist {
-    fn default() -> Dist {
-        Dist::new(Default::default(), Default::default())
     }
 }
 


### PR DESCRIPTION
Allows to use the `serve` function directly so we can use `xtask-wasm`'s dev-server without command and watcher.