### PR TITLE
Remove `platforms`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ env_logger = { version = "0.9.0", optional = true }
 fs_extra = "1.2.0"
 lazy_static = "1.4.0"
 log = "0.4.14"
-platforms = { version = "2.0.0", optional = true }
+platforms = { version = "3.0.1", optional = true }
 sass-rs = { version = "0.2.2", optional = true }
 walkdir = { version = "2.3.2", optional = true }
 # NOTE: we don't depend on this crate but we need to activate this feature otherwise it's super slow

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = ["src/**/*.rs", "README.md", "LICENSE.Apache-2.0", "LICENSE.MIT"]
 [features]
 run-example = ["xtask-wasm-run-example", "console_error_panic_hook", "wasm-bindgen", "env_logger"]
 sass = ["sass-rs", "walkdir"]
-wasm-opt = ["binary-install", "platforms"]
+wasm-opt = ["binary-install"]
 
 [dependencies]
 xtask-wasm-run-example = { version = "0.1.2", optional = true }
@@ -33,7 +33,6 @@ env_logger = { version = "0.9.0", optional = true }
 fs_extra = "1.2.0"
 lazy_static = "1.4.0"
 log = "0.4.14"
-platforms = { version = "3.0.1", optional = true }
 sass-rs = { version = "0.2.2", optional = true }
 walkdir = { version = "2.3.2", optional = true }
 # NOTE: we don't depend on this crate but we need to activate this feature otherwise it's super slow

--- a/src/wasm_opt.rs
+++ b/src/wasm_opt.rs
@@ -8,11 +8,23 @@ use std::{
 
 lazy_static! {
     static ref WASM_OPT_URL: String = {
+        let version = "110";
+
+        #[cfg(target_arch = "arm")]
+        let arch = "arm64";
+
+        #[cfg(target_arch = "x86_64")]
+        let arch = "x86_64";
+
+        #[cfg(target_os = "windows")]
+        let os = "windows";
+        #[cfg(target_os = "macos")]
+        let os = "macos";
+        #[cfg(target_os = "linux")]
+        let os = "linux";
+
         format!(
                 "https://github.com/WebAssembly/binaryen/releases/download/version_{version}/binaryen-version_{version}-{arch}-{os}.tar.gz",
-                version = "105",
-                arch = platforms::TARGET_ARCH,
-                os = platforms::TARGET_OS,
             )
     };
 }

--- a/src/wasm_opt.rs
+++ b/src/wasm_opt.rs
@@ -10,18 +10,11 @@ lazy_static! {
     static ref WASM_OPT_URL: String = {
         let version = "110";
 
-        #[cfg(target_arch = "arm")]
-        let arch = "arm64";
-
-        #[cfg(target_arch = "x86_64")]
-        let arch = "x86_64";
-
-        #[cfg(target_os = "windows")]
-        let os = "windows";
-        #[cfg(target_os = "macos")]
-        let os = "macos";
-        #[cfg(target_os = "linux")]
-        let os = "linux";
+        let os = std::env::consts::OS;
+        let mut arch = std::env::consts::ARCH;
+        if arch == "aarch64" {
+            arch = "arm64";
+        }
 
         format!(
                 "https://github.com/WebAssembly/binaryen/releases/download/version_{version}/binaryen-version_{version}-{arch}-{os}.tar.gz",


### PR DESCRIPTION
Platforms doesn't give `TARGET_OS` and `TARGET_ARCH` constants anymore so I we can replace by using `cfg` attributes directly